### PR TITLE
Fix detection of empty trees

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -16750,7 +16750,7 @@ var vm = new Vue({
                 return;
             }
 
-            if (parsed.length == 0) return;
+            if (parsed.children.length == 0) return;
             parsed = parsed.children[0];
 
             vm.currentTree = this.parseObjectBranch(parsed, true);

--- a/src/app.js
+++ b/src/app.js
@@ -115,7 +115,7 @@ var vm = new Vue({
                 return;
             }
 
-            if (parsed.length == 0) return;
+            if (parsed.children.length == 0) return;
             parsed = parsed.children[0];
 
             vm.currentTree = this.parseObjectBranch(parsed, true);


### PR DESCRIPTION
Previously, empty lists would cause a TypeError in Chrome, which could only be fixed by reloading the page.
